### PR TITLE
chore: Add Sentry error reporting to the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Code quality checking and enforcement is done with the following tools:
  - JaCoCo
  - SonarQube
 
+Error and exception logging is done using Sentry.
+
 ## Usage
 To use this template, create a new repository from it and follow the TODOs in
 the code, with the following additional changes.
@@ -26,6 +28,8 @@ the code, with the following additional changes.
  - Update copyright year in [TemplateApplication].
  - Update copyright year in [TemplateApplicationTest].
  - Update this README.
+ - Provide `SENTRY_DSN` and `SENTRY_ENVIRONMENT` as environmental variables
+   during deployment.
 
 ## Versioning
 This project uses [Semantic Versioning](semver.org).

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
   implementation "org.mapstruct:mapstruct:1.3.1.Final"
   annotationProcessor "org.mapstruct:mapstruct-processor:1.3.1.Final"
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.3.1.Final"
+
+  // Sentry reporting
+  compile 'io.sentry:sentry-spring:1.7.30'
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/template/config/SentryConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/template/config/SentryConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.template.config;
+
+import io.sentry.spring.SentryExceptionResolver;
+import io.sentry.spring.SentryServletContextInitializer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Configuration
+public class SentryConfiguration {
+
+  @Bean
+  public HandlerExceptionResolver sentryExceptionResolver() {
+    return new SentryExceptionResolver();
+  }
+
+  @Bean
+  public ServletContextInitializer sentryServletContextInitilizer() {
+    return new SentryServletContextInitializer();
+  }
+}


### PR DESCRIPTION
Update build.gradle to import the sentry-spring dependency.
Create SentryConfiguration to create the two Sentry beans as per the
Sentry Java installation guide.

Update the README to include that Sentry is used in the template and how
to configure it.

TISNEW-3904