### PR TITLE
feat: Add context path to application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 server:
-  # TODO: Update server port to a unique value.
+  # TODO: Update server port and context path to a unique value.
   port: 8080
+  servlet:
+    context-path: /template


### PR DESCRIPTION
Due to our AWS load balancer not supporting path rewriting we should be
using the context path to give each service a unique request path
prefix.

NO-TICKET