### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   // Code quality plugins
   id "checkstyle"
   id "jacoco"
-  id "org.sonarqube" version "2.8"
+  id "org.sonarqube" version "3.0"
 }
 
 // TODO: Update group to end with "admin" or "trainee".
@@ -42,7 +42,7 @@ dependencies {
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.3.1.Final"
 
   // Sentry reporting
-  compile "io.sentry:sentry-spring:1.7.30"
+  implementation "io.sentry:sentry-spring:1.7.30"
 }
 
 checkstyle {


### PR DESCRIPTION
Upgrade sonarqube to 3.0.

Change Sentry to use `implementation` config instead of the deprecated
`compile`.

NO-TICKET