### PR TITLE
chore: Improve performance of Dockerize step

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -154,7 +154,7 @@ jobs:
 #          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 #          ECR_REPOSITORY: ${{ github.event.repository.name }}
 #        run: |
-#          ./gradlew bootBuildImage --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+#          ./gradlew bootBuildImage -x bootJar --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
 #          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REPOSITORY
 #


### PR DESCRIPTION
The `bootBuildImage` runs the `bootJar` task by default, but as we
already build the JAR in the `assemble` step and then download it we
don't need to repeat this task.

NO-TICKET