### PR TITLE
chore: Remove actionspanel configuration

### DIFF
--- a/.actionspanel/buttons.yml
+++ b/.actionspanel/buttons.yml
@@ -1,8 +1,0 @@
-buttons:
-  - title: Run CI/CD
-    action: "run_ci-cd"
-    description: Run CI/CD
-
-  - title: Purge Artifacts
-    action: "purge_artifacts"
-    description: Purge Artifacts

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -2,8 +2,7 @@ name: CI/CD Workflow
 
 on:
   push:
-  repository_dispatch:
-    types: [run_ci-cd]
+  workflow_dispatch:
 
 jobs:
   assemble:

--- a/.github/workflows/purge-artifacts.yml
+++ b/.github/workflows/purge-artifacts.yml
@@ -1,10 +1,9 @@
 name: Purge Old Artifacts
 
 on:
-  repository_dispatch:
-    types: [purge_artifacts]
   schedule:
     - cron: '0 1 * * *'
+  workflow_dispatch:
 
 jobs:
   purge:


### PR DESCRIPTION
GitHub supports workflow triggers now which can be used in place of
actionspanel and repository dispatch.

NO-TICKET