### PR TITLE
chore: Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - Health-Education-England/full-stack
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - Health-Education-England/full-stack
+      - Health-Education-England/operations


### PR DESCRIPTION
Set up the default dependabot configuration, with weekly analysis of
both gradle and GHA and suitable teams asked for review.

TIS21-1356