### PR TITLE
chore: remove JUnit vintage exclusion from deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,7 @@ dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
-  testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    exclude group: "org.junit.vintage", module: "junit-vintage-engine"
-  }
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"


### PR DESCRIPTION
JUnit vintage engine is no longer included in the spring boot test starter, so no longer needs an explicit exclusion.

TIS21-SHED