### PR TITLE
chore: upgrade sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
   // Sentry reporting
   val sentryVersion = "7.6.0"
-  implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
 }
 


### PR DESCRIPTION
Sentry should use a different dependency for Spring Boot 3 compatibility.

TIS21-SHED